### PR TITLE
Run tests on Xcode 15.2 and setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         xcode:
-        # - "15.0"
+        - "15.2"
         - "14.3.1"
         - "14.1"
         include:
-        # - xcode: "15.0"
-        #   macos: macOS-13
-        #   destination: "platform=iOS Simulator,name=iPhone 14,OS=17.0"
+        - xcode: "15.2"
+          macos: macOS-13
+          destination: "platform=iOS Simulator,name=iPhone 14,OS=17.2"
         - xcode: "14.3.1"
           macos: macOS-13
           destination: "platform=iOS Simulator,name=iPhone 14,OS=16.4"


### PR DESCRIPTION
Xcode 15.2 has since been released so we should run unit tests against this toolchain.

Additionally, I added a Dependabot configuration to ensure that we keep the GitHub Actions dependencies updated semi-frequently. 