### PR TITLE
Reintroduce CocoaPod support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,13 @@ jobs:
       uses: actions/checkout@v3
     - name: Run Tests
       run: xcodebuild clean test -scheme TwitterImagePipeline-Package -destination '${{ matrix.destination }}'
-
+  cocoapods:
+    name: CocoaPods
+    runs-on: macOS-13
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Validate the Pod
+      run: pod lib lint TwitterImagePipeline.podspec --allow-warnings

--- a/Sources/TwitterImagePipeline/TIP_ProjectCommon.h
+++ b/Sources/TwitterImagePipeline/TIP_ProjectCommon.h
@@ -11,7 +11,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <TIPLogger.h>
+#import "TIPLogger.h"
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/TwitterImagePipeline/include/TIPImageCodecCatalogue.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageCodecCatalogue.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <TIPImageCodecs.h>
+#import "TIPImageCodecs.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/TwitterImagePipeline/include/TIPImageCodecs.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageCodecs.h
@@ -8,7 +8,7 @@
 
 #import <CoreGraphics/CGGeometry.h>
 #import <Foundation/Foundation.h>
-#import <TIPImageTypes.h>
+#import "TIPImageTypes.h"
 #import <UIKit/UIView.h> // UIViewContentMode
 
 @protocol TIPImageEncoder;

--- a/Sources/TwitterImagePipeline/include/TIPImageContainer.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageContainer.h
@@ -7,7 +7,7 @@
 //
 
 #import <ImageIO/CGImageSource.h>
-#import <TIPImageUtils.h>
+#import "TIPImageUtils.h"
 #import <UIKit/UIImage.h>
 #import <UIKit/UIView.h>
 

--- a/Sources/TwitterImagePipeline/include/TIPImageFetchDelegate.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageFetchDelegate.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 Twitter. All rights reserved.
 //
 
-#import <TIPDefinitions.h>
-#import <TIPImageUtils.h>
+#import "TIPDefinitions.h"
+#import "TIPImageUtils.h"
 #import <UIKit/UIImage.h>
 #import <UIKit/UIView.h>
 

--- a/Sources/TwitterImagePipeline/include/TIPImageFetchMetrics.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageFetchMetrics.h
@@ -8,8 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <TIPDefinitions.h>
-#import <TIPImageFetchOperation.h>
+#import "TIPDefinitions.h"
+#import "TIPImageFetchOperation.h"
 
 @class TIPImageFetchMetricInfo;
 

--- a/Sources/TwitterImagePipeline/include/TIPImageFetchOperation.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageFetchOperation.h
@@ -6,10 +6,10 @@
 //  Copyright (c) 2015 Twitter. All rights reserved.
 //
 
-#import <TIPDefinitions.h>
-#import <TIPImageContainer.h>
-#import <TIPImageUtils.h>
-#import <TIPSafeOperation.h>
+#import "TIPDefinitions.h"
+#import "TIPImageContainer.h"
+#import "TIPImageUtils.h"
+#import "TIPSafeOperation.h"
 #import <UIKit/UIImage.h>
 
 @class TIPImagePipeline;

--- a/Sources/TwitterImagePipeline/include/TIPImageFetchProgressiveLoadingPolicies.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageFetchProgressiveLoadingPolicies.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Twitter. All rights reserved.
 //
 
-#import <TIPProgressive.h>
+#import "TIPProgressive.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/TwitterImagePipeline/include/TIPImageFetchRequest.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageFetchRequest.h
@@ -6,8 +6,8 @@
 //  Copyright © 2020 Twitter. All rights reserved.
 //
 
-#import <TIPDefinitions.h>
-#import <TIPProgressive.h>
+#import "TIPDefinitions.h"
+#import "TIPProgressive.h"
 
 @protocol TIPImageFetchOperationUnderlyingContext;
 @protocol TIPImageFetchTransformer;

--- a/Sources/TwitterImagePipeline/include/TIPImageUtils.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageUtils.h
@@ -8,7 +8,7 @@
 
 #import <ImageIO/CGImageProperties.h>
 #import <ImageIO/CGImageSource.h>
-#import <TIPImageTypes.h>
+#import "TIPImageTypes.h"
 #import <UIKit/UIImage.h>
 #import <UIKit/UIScreen.h>
 #import <UIKit/UIView.h>

--- a/Sources/TwitterImagePipeline/include/TIPImageViewFetchHelper.h
+++ b/Sources/TwitterImagePipeline/include/TIPImageViewFetchHelper.h
@@ -6,8 +6,8 @@
 //  Copyright © 2020 Twitter. All rights reserved.
 //
 
-#import <TIPImageFetchDelegate.h>
-#import <TIPImageUtils.h>
+#import "TIPImageFetchDelegate.h"
+#import "TIPImageUtils.h"
 #import <UIKit/UIView.h>
 
 @class TIPImageFetchMetrics;

--- a/Sources/TwitterImagePipeline/include/TIPProgressive.h
+++ b/Sources/TwitterImagePipeline/include/TIPProgressive.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <TIPImageUtils.h>
+#import "TIPImageUtils.h"
 
 @class TIPImageFetchOperation;
 

--- a/Sources/TwitterImagePipeline/include/UIImage+TIPAdditions.h
+++ b/Sources/TwitterImagePipeline/include/UIImage+TIPAdditions.h
@@ -7,8 +7,8 @@
 //
 
 #import <ImageIO/ImageIO.h>
-#import <TIPImageTypes.h>
-#import <TIPImageUtils.h>
+#import "TIPImageTypes.h"
+#import "TIPImageUtils.h"
 #import <UIKit/UIImage.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/TwitterImagePipeline/include/UIView+TIPImageFetchable.h
+++ b/Sources/TwitterImagePipeline/include/UIView+TIPImageFetchable.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Twitter. All rights reserved.
 //
 
-#import <TIPImageFetchable.h>
+#import "TIPImageFetchable.h"
 #import <UIKit/UIImageView.h>
 
 @class TIPImageViewFetchHelper;

--- a/Sources/TwitterImagePipelineMP4Codec/include/TIPXMP4Codec.h
+++ b/Sources/TwitterImagePipelineMP4Codec/include/TIPXMP4Codec.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Twitter. All rights reserved.
 //
 
-#import <TIPImageCodecs.h>
+#import "TIPImageCodecs.h"
 
 @protocol TIPXMP4DecoderConfig;
 

--- a/Sources/TwitterImagePipelineWebPCodec/include/TIPXWebPCodec.h
+++ b/Sources/TwitterImagePipelineWebPCodec/include/TIPXWebPCodec.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Twitter. All rights reserved.
 //
 
-#import <TIPImageCodecs.h>
+#import "TIPImageCodecs.h"
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/TwitterImagePipeline.podspec
+++ b/TwitterImagePipeline.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name             = 'TwitterImagePipeline'
+  s.version          = '2.25.2'
+  s.compiler_flags   = '-DTIP_PROJECT_VERSION=2.25'
+  s.summary          = 'Twitter Image Pipeline is a robust and performant image loading and caching framework for iOS'
+  s.description      = 'Twitter created a framework for image loading/caching in order to fulfill the numerous needs of Twitter for iOS including being fast, safe, modular and versatile.'
+  s.homepage         = 'https://github.com/twitter/ios-twitter-image-pipeline'
+  s.license          = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
+  s.author           = { 'Twitter' => 'opensource@twitter.com' }
+  s.source           = { :git => 'https://github.com/twitter/ios-twitter-image-pipeline.git', :tag => s.version.to_s }
+  s.ios.deployment_target = '10.0'
+  s.swift_versions   = [ 5.0 ]
+  s.source_files = 'Sources/TwitterImagePipeline/**/*.{h,m}', 'Sources/TIPUtils/**/*.{h,m}'
+  s.public_header_files = 'Sources/TwitterImagePipeline/include/*.h'
+end


### PR DESCRIPTION
We originally created this fork purely because the main twitter/ios-twitter-image-pipeline is no longer maintained and we needed SPM support, but now we also want to use this fork for other enhancements (#3).

Since we are yet to complete the transition to SPM, we need this fork to also offer partial CocoaPods support. Unlike the main repo, we are only supporting the main target and not the additional codecs to keep things simple.

When testing this change, I realised that I used the incorrect type of imports so I have also corrected this in afb19b5